### PR TITLE
[FIX] Fix close button aligned center

### DIFF
--- a/public/streetlives.css
+++ b/public/streetlives.css
@@ -239,7 +239,7 @@
   width: 100%;
   height: 35px;
   line-height: 35px;
-  text-align: center;
+  text-align: right;
   text-decoration: none;
   text-transform: uppercase;
   vertical-align: middle;

--- a/sources/scss/button.scss
+++ b/sources/scss/button.scss
@@ -34,7 +34,7 @@
   width: 100%;
   height: 35px;
   line-height: 35px;
-  text-align: center;
+  text-align: right;
   text-decoration: none;
   text-transform: uppercase;
   vertical-align: middle;


### PR DESCRIPTION
Text align right to fix close button on
location popup in firefox.
